### PR TITLE
feat: log CAR indexing data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-ipfs-indexing-lambda",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-ipfs-indexing-lambda",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.41.0",

--- a/src/source.js
+++ b/src/source.js
@@ -53,7 +53,7 @@ async function openS3Stream (bucketRegion, url, car, retries = s3MaxRetries, ret
   }
 
   const stats = {
-    lastModified: s3Request.LastModified,
+    lastModified: s3Request.LastModified?.getTime(),
     contentLength: s3Request.ContentLength
   }
 

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -23,14 +23,14 @@ t.afterEach(() => {
 
 t.test('openS3Stream - succeed', async t => {
   const length = 148
-  const modified = new Date('2022-06-13T10:04:00.044Z')
+  const modified = new Date('2022-06-13T10:04:00.044Z').getTime()
   mockS3GetObject('cars', 'file1.car', readMockData('cars/file1.car'), length, modified)
 
   const { stats } = await openS3Stream('us-east-1', new URL('s3://cars/file1.car'), 3, 10)
   t.equal(logger.warn.getCalls().length, 0)
   t.equal(logger.error.getCalls().length, 0)
   t.equal(stats.contentLength, length)
-  t.equal(stats.lastModified.getTime(), modified.getTime())
+  t.equal(stats.lastModified, modified)
 })
 
 t.test('openS3Stream - reports S3 errors', async t => {

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -22,11 +22,15 @@ t.afterEach(() => {
 })
 
 t.test('openS3Stream - succeed', async t => {
-  mockS3GetObject('cars', 'file1.car', readMockData('cars/file1.car'), 148)
+  const length = 148
+  const modified = new Date('2022-06-13T10:04:00.044Z')
+  mockS3GetObject('cars', 'file1.car', readMockData('cars/file1.car'), length, modified)
 
-  await openS3Stream('us-east-1', new URL('s3://cars/file1.car'), 3, 10)
+  const { stats } = await openS3Stream('us-east-1', new URL('s3://cars/file1.car'), 3, 10)
   t.equal(logger.warn.getCalls().length, 0)
   t.equal(logger.error.getCalls().length, 0)
+  t.equal(stats.contentLength, length)
+  t.equal(stats.lastModified.getTime(), modified.getTime())
 })
 
 t.test('openS3Stream - reports S3 errors', async t => {

--- a/test/utils/mock.js
+++ b/test/utils/mock.js
@@ -34,7 +34,7 @@ function mockDynamoGetItemCommand(table, keyName, keyValue, response) {
   }
 }
 
-function mockS3GetObject(bucket, key, response, length, index = 0) {
+function mockS3GetObject(bucket, key, response, length, modified = new Date(), index = 0) {
   s3Mock
     .on(GetObjectCommand, {
       Bucket: bucket,
@@ -49,7 +49,7 @@ function mockS3GetObject(bucket, key, response, length, index = 0) {
         response = await response()
       }
 
-      return { Body: response ? Readable.from(response) : undefined, ContentLength: length }
+      return { Body: response ? Readable.from(response) : undefined, ContentLength: length, LastModified: modified }
     })
 }
 

--- a/test/utils/mock.js
+++ b/test/utils/mock.js
@@ -34,7 +34,7 @@ function mockDynamoGetItemCommand(table, keyName, keyValue, response) {
   }
 }
 
-function mockS3GetObject(bucket, key, response, length, modified = new Date(), index = 0) {
+function mockS3GetObject(bucket, key, response, length, modified = Date.now(), index = 0) {
   s3Mock
     .on(GetObjectCommand, {
       Bucket: bucket,
@@ -49,7 +49,7 @@ function mockS3GetObject(bucket, key, response, length, modified = new Date(), i
         response = await response()
       }
 
-      return { Body: response ? Readable.from(response) : undefined, ContentLength: length, LastModified: modified }
+      return { Body: response ? Readable.from(response) : undefined, ContentLength: length, LastModified: new Date(modified) }
     })
 }
 


### PR DESCRIPTION
This PR modifies `openS3Stream` to return stats about the CAR file being indexed and then logs useful information when indexing completes.

The log records:

* CAR "ID" - just incase we need to identify a specific CAR.
* Duration (how long it took to index) - so we know how long it takes to index a CAR in total.
* Resumed or not (if it was already partially indexed and then resumed) - so we know if we're looking at data for a whole CAR or a subset.
* Content length - so we can know if a CAR was indexed quickly because it was small or slowly because it was large.
* Last modified time (unix timestamp in ms) - so we can determine how long it is currently taking between a CAR being uploaded and it being indexed.
* Number of blocks indexed - so we can know if a CAR was indexed quickly because there was only a few blocks or slowly because there was lots.

